### PR TITLE
Add tsaoptions.json from microsoft/go-images

### DIFF
--- a/.config/tsa/tsaoptions.json
+++ b/.config/tsa/tsaoptions.json
@@ -1,0 +1,14 @@
+{
+  "codebaseName": "Go",
+  "notificationAliases": [
+    "golangdev@microsoft.com"
+  ],
+  "codebaseAdmins": [
+    "redmond\\golangdev"
+  ],
+  "instanceUrl": "https://devdiv.visualstudio.com/",
+  "projectName": "DEVDIV",
+  "areaPath": "DevDiv\\GoLang",
+  "iterationPath": "DevDiv",
+  "allTools": true
+}


### PR DESCRIPTION
* Like https://github.com/microsoft/go-images-versions/pull/4, we also need the `.config/tsa/tsaoptions.json` file for a clean build.
* For https://github.com/microsoft/go-lab/issues/243

Should fix https://dev.azure.com/dnceng/internal/_build/results?buildId=2796537&view=logs&j=cd4e2ccb-d0cd-5593-0e83-8a21caeb442f&t=244bfde9-5a47-5f33-4226-61136ead829e&l=939