### PR TITLE
Add es-metadata.yml based on microsoft/go

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,8 @@
+schemaVersion: 0.0.1
+isProduction: true
+accountableOwners:
+  service: 5afbffc6-5070-413d-84a2-cf156c3dce91
+routing:
+  defaultAreaPath:
+    org: msazure
+    path: One\DevDiv\GoLang


### PR DESCRIPTION
* https://github.com/microsoft/go-lab/issues/252

We didn't get an auto-PR for this repo, likely because of the time when we created the mirror (the mirror repo had a file like this pre-populated), and the way we resolved this back then: deleting the file because it was an unknown and contains internal information. I suspect the deletion (via force push) confused the tool.