### PR TITLE
Configure dependabot settings in Azure DevOps

### DIFF
--- a/.azuredevops/dependabot.yml
+++ b/.azuredevops/dependabot.yml
@@ -1,0 +1,5 @@
+version: 2
+
+# Disabling dependabot on Azure DevOps as this is a mirrored repo. Updates should go through github.
+enable-campaigned-updates: false
+enable-security-updates: false


### PR DESCRIPTION
Disable dependabot updates for a mirrored repository.